### PR TITLE
feat(release): add GTNH RP updater metadata and release asset

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,6 +6,9 @@ on:
       version:
         description: 'Version number that follows SemVer (x.y.z), do not include the "v" prefix (e.g., 1.0.0)'
         required: true
+      pack_game_version:
+        description: 'Optional GTNH game version(s) for updater metadata, SemVer list separated by ";" (e.g., 2.7.4;2.8.0)'
+        required: false
   pull_request:
     types:
       - closed
@@ -17,6 +20,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions: write-all
+    env:
+      VERSION: ${{ github.event.inputs.version || github.event.pull_request.head.ref }}
+      PACK_GAME_VERSION: ${{ github.event.inputs.pack_game_version || github.event.inputs.version || github.event.pull_request.head.ref }}
 
     steps:
       - name: Checkout
@@ -38,6 +44,14 @@ jobs:
             exit 1
           fi
 
+      - name: Check pack_game_version follows SemVer list
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pack_game_version != ''
+        run: |
+          if [[ ! "${{ github.event.inputs.pack_game_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([[:space:]]*;[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+)*$ ]]; then
+            echo "pack_game_version must be a SemVer list separated by ';' (e.g., 2.7.4;2.8.0)."
+            exit 1
+          fi
+
       - name: Install NodeJS
         uses: actions/setup-node@v4
         with:
@@ -53,8 +67,18 @@ jobs:
           cd ./.scripts
           mv config.example.json config.json
           npm run cleanup
-          npm run update ${{ github.event.inputs.version || github.event.pull_request.head.ref }}
+          npm run update ${{ env.VERSION }} "${{ env.PACK_GAME_VERSION }}"
           npm run zip
+
+      - name: Create GTNH updater metadata
+        run: |
+          cat > gtnh-pack-update.json <<EOF
+          {
+            "schema": 1,
+            "pack_version": "${{ env.VERSION }}",
+            "pack_game_version": "${{ env.PACK_GAME_VERSION }}"
+          }
+          EOF
 
       - name: Create tag
         uses: actions/github-script@v7
@@ -63,7 +87,7 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/v${{ github.event.inputs.version || github.event.pull_request.head.ref }}',
+              ref: 'refs/tags/v${{ env.VERSION }}',
               sha: context.sha
             });
 
@@ -74,16 +98,24 @@ jobs:
             const release = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${{ github.event.inputs.version || github.event.pull_request.head.ref }}`,
-              name: `v${{ github.event.inputs.version || github.event.pull_request.head.ref }}`,
+              tag_name: `v${{ env.VERSION }}`,
+              name: `v${{ env.VERSION }}`,
               body: '',
               target_commitish: context.sha
             });
 
-            github.rest.repos.uploadReleaseAsset({
+            await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              name: 'GTNH-Faithful-x32 v${{ github.event.inputs.version || github.event.pull_request.head.ref }}.zip',
+              name: 'GTNH-Faithful-x32 v${{ env.VERSION }}.zip',
               data: require('fs').readFileSync('./pack.zip')
+            });
+
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.data.id,
+              name: 'gtnh-pack-update.json',
+              data: require('fs').readFileSync('./gtnh-pack-update.json')
             });

--- a/.scripts/runs/update.ts
+++ b/.scripts/runs/update.ts
@@ -8,4 +8,4 @@ if (args.length === 0) {
 	consola.error('Please provide a version number, e.g.: "npm run update 1.0.0"');
 }
 
-else updatePack(args[0]);
+else updatePack(args[0], args[1] ?? args[0]);

--- a/.scripts/src/update.ts
+++ b/.scripts/src/update.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import { packProgress } from './progress.ts';
 import { PACK_MCMETA } from './constants.ts';
 
-export async function updatePack(version: string) {
+export async function updatePack(version: string, packGameVersion = version) {
 
 	const percentage = packProgress();
 
@@ -11,7 +11,18 @@ export async function updatePack(version: string) {
 		pack: {
 			pack_format: 1,
 			description: `§6GT New Horizons §bFaithful x32 §6By Ethryan §bv${version} §r(${percentage}% done)`
-		}
+		},
+		gtnh_resource_pack_updater: {
+			schema: 1,
+			pack_name: "GTNH Faithful x32",
+			pack_version: version,
+			pack_game_version: packGameVersion,
+			source: {
+				type: "github_releases",
+				owner: "Ethryan",
+				repo: "GTNH-Faithful-Textures"
+			}
+		},
 	}
 
 	fs.writeFileSync(PACK_MCMETA, JSON.stringify(packMCMETA, null, 2));

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -2,5 +2,16 @@
   "pack": {
     "pack_format": 1,
     "description": "§6GT New Horizons §bFaithful x32 §6By Ethryan §bv2.1.4 §r(53% done)"
+  },
+  "gtnh_resource_pack_updater": {
+    "schema": 1,
+    "pack_name": "GTNH Faithful x32",
+    "pack_version": "2.1.4",
+    "pack_game_version": "2.1.4",
+    "source": {
+      "type": "github_releases",
+      "owner": "Ethryan",
+      "repo": "GTNH-Faithful-Textures"
+    }
   }
 }


### PR DESCRIPTION
- add `gtnh_resource_pack_updater` block to `pack.mcmeta`
- preserve updater metadata in `.scripts/src/update.ts` (no overwrite loss on release)
- pass optional `pack_game_version` through `.scripts/runs/update.ts`
- extend `.github/workflows/update.yml` to:
  - accept and validate optional `pack_game_version` (supports `;`-separated semver list)
  - generate and upload `gtnh-pack-update.json` release asset
  - unify version usage via `env.VERSION` and `env.PACK_GAME_VERSION`